### PR TITLE
Update game statistics and logo position

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,33 +25,35 @@
         <!-- Players Section -->
         <div class="players-container">
             <!-- Player 1 -->
-            <div class="player-card" id="player1">
-                <div class="player-header">
-                    <div class="player-avatar">🧑‍💼</div>
-                    <h2 class="player-name">Player 1</h2>
-                    <div class="crown-container" id="crown1">
-                        <i class="fas fa-crown"></i>
+            <div class="player-section">
+                <div class="player-card" id="player1">
+                    <div class="player-header">
+                        <div class="player-avatar">🧑‍💼</div>
+                        <h2 class="player-name">Player 1</h2>
+                        <div class="crown-container" id="crown1">
+                            <i class="fas fa-crown"></i>
+                        </div>
+                    </div>
+                    <div class="score-display">
+                        <div class="score-label">Score</div>
+                        <div class="score-value" id="score1">0</div>
+                    </div>
+                    <div class="dice-container">
+                        <div class="dice-wrapper">
+                            <img class="dice-img" id="dice1" src="images/dice1.png" alt="Player 1 Dice">
+                            <div class="dice-shadow"></div>
+                        </div>
+                    </div>
+                    <div class="last-roll">
+                        Last roll: <span id="lastRoll1">-</span>
                     </div>
                 </div>
-                <div class="score-display">
-                    <div class="score-label">Score</div>
-                    <div class="score-value" id="score1">0</div>
-                </div>
-                <div class="dice-container">
-                    <div class="dice-wrapper">
-                        <img class="dice-img" id="dice1" src="images/dice1.png" alt="Player 1 Dice">
-                        <div class="dice-shadow"></div>
-                    </div>
-                </div>
-                <div class="last-roll">
-                    Last roll: <span id="lastRoll1">-</span>
-                </div>
-            </div>
 
-            <!-- VS Separator -->
-            <div class="vs-separator">
-                <div class="vs-text">VS</div>
-                <div class="lightning">⚡</div>
+                <!-- VS Separator -->
+                <div class="vs-separator">
+                    <div class="vs-text">VS</div>
+                    <div class="lightning">⚡</div>
+                </div>
             </div>
 
             <!-- Player 2 -->

--- a/index.js
+++ b/index.js
@@ -165,14 +165,25 @@ function determineWinner(roll1, roll2) {
         message = `🏆 Player 1 wins this round! (${roll1} vs ${roll2})`;
         winner = 1;
         showWinnerEffects(1);
+        // Update round wins in statistics
+        gameState.gameStats.player1Wins++;
     } else if (roll2 > roll1) {
         message = `🏆 Player 2 wins this round! (${roll2} vs ${roll1})`;
         winner = 2;
         showWinnerEffects(2);
+        // Update round wins in statistics
+        gameState.gameStats.player2Wins++;
     } else {
         message = `🤝 It's a draw! Both rolled ${roll1}`;
         showDrawEffect();
+        // Update draws in statistics
+        gameState.gameStats.draws++;
     }
+    
+    // Update total games and display
+    gameState.gameStats.totalGames++;
+    updateStatsDisplay();
+    saveGameStats();
     
     elements.statusMessage.textContent = message;
     
@@ -280,17 +291,10 @@ function announceGameWinner(winner) {
     }, 3000);
 }
 
-// Update Game Statistics
+// Update Game Statistics (for full game wins - 50 points)
 function updateGameStats(winner) {
-    if (winner === 1) {
-        gameState.gameStats.player1Wins++;
-    } else if (winner === 2) {
-        gameState.gameStats.player2Wins++;
-    } else {
-        gameState.gameStats.draws++;
-    }
-    gameState.gameStats.totalGames++;
-    
+    // This function is called when someone wins the full game (reaches 50 points)
+    // Individual round wins are already tracked in determineWinner function
     updateStatsDisplay();
     saveGameStats();
 }

--- a/styles.css
+++ b/styles.css
@@ -144,15 +144,22 @@ body {
 .players-container {
     display: flex;
     justify-content: space-between;
-    align-items: stretch;
+    align-items: flex-start;
     gap: 20px;
     margin-bottom: 40px;
     animation: slideInUp 1s ease-out 0.4s both;
 }
 
+.player-section {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+}
+
 /* Player Cards */
 .player-card {
-    flex: 1;
     background: rgba(255, 255, 255, 0.1);
     backdrop-filter: blur(15px);
     border-radius: 20px;
@@ -161,6 +168,7 @@ body {
     transition: all 0.3s ease;
     position: relative;
     overflow: hidden;
+    width: 100%;
 }
 
 .player-card::before {
@@ -294,6 +302,7 @@ body {
     align-items: center;
     justify-content: center;
     min-width: 80px;
+    margin-top: 10px;
 }
 
 .vs-text {
@@ -483,10 +492,10 @@ body {
     }
     
     .vs-separator {
-        order: 1;
         flex-direction: row;
         justify-content: center;
         padding: 10px 0;
+        margin-top: 0;
     }
     
     .vs-text {


### PR DESCRIPTION
Update game statistics to track individual round outcomes and reposition the 'VS' separator below Player 1.

The game statistics logic was updated to track individual round wins/losses/draws instead of only full game wins (reaching 50 points). This means 'wins' in the statistics now refer to rounds won, and 'total games' increments with each round played. This addresses the user's request for "total wins" to be counted, interpreting it as round wins. The 'VS' separator was moved from between players to below Player 1 as requested.